### PR TITLE
Fix snapping to the wrong diagonal axis

### DIFF
--- a/src/main/java/com/bebeli555/ElytraBot/Diagonal.java
+++ b/src/main/java/com/bebeli555/ElytraBot/Diagonal.java
@@ -292,6 +292,11 @@ public class Diagonal {
 	}
 	
 	public static void SetYaws() {
+		// First check if Yaw is out of valid range (positive or negative 0-180)
+		// This prevents snapping to the wrong axis on diagonals
+		if (Yaw < -180.0) Yaw += 360;
+		else if (Yaw > 180) Yaw -= 360;
+		
 		//These shits took fucking an hour to figure out...
 		if (direction.equals(EnumFacing.NORTH)) {
 			double YawCheck = Closer(135, -135, Yaw);


### PR DESCRIPTION
Added a check for player Yaw being outside the valid range (0 to 180 and -0 to -180). There might be a bit nicer way to do this but this worked for me.

The issue I was facing is that sometimes on diagonals, the bot would snap to a different axis than the one the player was facing. For example I noticed that Forge was reporting Yaw as `-225` instead of `135`. After adding the fix I had no issues on any axis.

Built and tested using IntelliJ; latest Forge for Minecraft 1.12.2